### PR TITLE
Ignore tagged template literals

### DIFF
--- a/src/rules/no-straight-quotes.ts
+++ b/src/rules/no-straight-quotes.ts
@@ -128,7 +128,13 @@ const rule: Rule.RuleModule = {
     return {
       JSXText: (node: JSXText) => handleNode(node, 0),
       Literal: (node: Literal) => handleNode(node, 1),
-      TemplateLiteral: (node: TemplateLiteral) => handleNode(node, 1),
+      TemplateLiteral: (node: TemplateLiteral) => {
+        const parent = (node as unknown as { parent: Node }).parent
+        const hasTag =
+          parent.type === "TaggedTemplateExpression" && node === parent.quasi
+        if (hasTag) return
+        return handleNode(node, 1)
+      },
     }
   },
 }

--- a/tests/rules/no-straight-quotes.test.ts
+++ b/tests/rules/no-straight-quotes.test.ts
@@ -28,6 +28,9 @@ ruleTester.run("curly-quotes", rule, {
     {
       code: "var str = `Hello, ${'world'}!`",
     },
+    {
+      code: "String.raw`Hello, 'world'`",
+    },
   ],
   invalid: [
     /**


### PR DESCRIPTION
Tagged template literals are quite often used for things like SQL where curly quotes are not desirable. Also, by ignoring expressions like

```
String.raw`Don't change my quotes here please!`
```

there is now an escape hatch where you can use straight quotes (for things like code snippets) without having to clutter your codebase with eslint-disable comments.