### PR TITLE
Add options to ignore straight quotes used in function calls and JSX attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ You may customize the characters used to replace straight quotes:
         "single-closing": "’", // This character is also used to replace apostrophes.
         "double-opening": "“",
         "double-closing": "”"
+        "ignored-jsx-attributes": ["className"], // Straight quotes in these JSX attributes are ignored.
+        "ignored-function-calls": ["Error"], // Straight quotes passed as parameters to these functions are ignored.
       }
     ]
   }

--- a/tests/rules/no-straight-quotes.test.ts
+++ b/tests/rules/no-straight-quotes.test.ts
@@ -31,6 +31,12 @@ ruleTester.run("curly-quotes", rule, {
     {
       code: "String.raw`Hello, 'world'`",
     },
+    {
+      code: "<div className=\"after:contents-[''] before:contents-['']\" />",
+    },
+    {
+      code: "<div className={clsx(\"after:contents-['']\", \"before:contents-['']\")} />",
+    },
   ],
   invalid: [
     /**

--- a/tests/rules/no-straight-quotes.test.ts
+++ b/tests/rules/no-straight-quotes.test.ts
@@ -37,6 +37,9 @@ ruleTester.run("curly-quotes", rule, {
     {
       code: "<div className={clsx(\"after:contents-['']\", \"before:contents-['']\")} />",
     },
+    {
+      code: 'throw new Error("Shouldn\'t have quotes " + upperCase("replaced \\"\\":)"));',
+    },
   ],
   invalid: [
     /**


### PR DESCRIPTION
As discussed in #15, this PR adds two new options `ignored-jsx-attributes` and `ignored-function-calls` to ignore any straight quotes used in specific JSX attributes and function calls.

For now, I've added the following as defaults:
- `ignored-jsx-attributes: ["className"]`: the `className` JSX attribute, where quotes are unlikely in the first place, but can be used in eg. Tailwind
- `ignored-function-calls`: the `Error` constructor, where most developers wouldn't expect their quotes to be changed

Note: I'm treating both `NewExpression` and `CallExpression` as function calls, since I don't think there has to be a distinction for this plugin.