### PR TITLE
Add `ignored-jsx-elements` option to ignore straight quotes in element contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ You may customize the characters used to replace straight quotes:
         "single-closing": "’", // This character is also used to replace apostrophes.
         "double-opening": "“",
         "double-closing": "”",
+        "ignored-jsx-elements": ["script", "style"], // Straight quotes in these JSX elements are ignored.
         "ignored-jsx-attributes": ["className"], // Straight quotes in these JSX attributes are ignored.
         "ignored-function-calls": ["Error"] // Straight quotes passed as parameters to these functions are ignored.
       }

--- a/tests/rules/no-straight-quotes.test.ts
+++ b/tests/rules/no-straight-quotes.test.ts
@@ -32,6 +32,12 @@ ruleTester.run("curly-quotes", rule, {
       code: "String.raw`Hello, 'world'`",
     },
     {
+      code: "<style>{\".heading::after { content: ''; }\"}</style>",
+    },
+    {
+      code: "<script>var a = '';</script>",
+    },
+    {
       code: "<div className=\"after:contents-[''] before:contents-['']\" />",
     },
     {


### PR DESCRIPTION
This PR is similar in concept to #16. It adds a new `ignored-jsx-elements` option which allows customizing of JSX elements for which the rule should be ignored. By default, straight quotes found in the contents of `<script>` and `<style>` will be ignored.