### PR TITLE
Handle `context.parserServices` being `undefined`

### DIFF
--- a/src/rules/no-straight-quotes.ts
+++ b/src/rules/no-straight-quotes.ts
@@ -173,7 +173,7 @@ const rule: Rule.RuleModule = {
     }
 
     // Vue.js
-    if (context.parserServices.defineTemplateBodyVisitor) {
+    if (context.parserServices?.defineTemplateBodyVisitor) {
       return context.parserServices.defineTemplateBodyVisitor(
         // Event handlers for <template>.
         {


### PR DESCRIPTION
After upgrading to ESLint 9, I started getting an error from this rule. It seems like `context.parserServices` can be `undefined` now.

I haven't verified that the Vue.js stuff works in ESLint 9 - we don't use Vue. This PR just makes the rule stop erroring.